### PR TITLE
Added supervisor and year of study as required by the dissertation to the title page

### DIFF
--- a/common/common.tex
+++ b/common/common.tex
@@ -39,9 +39,9 @@
 \makeatletter
 \newcommand{\@assignment}[0]{Assignment}
 \newcommand{\assignment}[1]{\renewcommand{\@assignment}{#1}}
-\newcommand{\@supervisor}[0]{Your Supervisor's Name}
+\newcommand{\@supervisor}[0]{}
 \newcommand{\supervisor}[1]{\renewcommand{\@supervisor}{#1}}
-\newcommand{\@yearofstudy}[0]{3\textsuperscript{rd}}
+\newcommand{\@yearofstudy}[0]{}
 \newcommand{\yearofstudy}[1]{\renewcommand{\@yearofstudy}{#1}}
 \makeatletter
 

--- a/common/common.tex
+++ b/common/common.tex
@@ -19,7 +19,7 @@
 \usepackage{natbib}
 \usepackage[dvipsnames]{xcolor}
 \usepackage[sc]{mathpazo}
-\linespread{1.05} 
+\linespread{1.05}
 \usepackage[T1]{fontenc}
 \usepackage{minted}
 
@@ -39,6 +39,10 @@
 \makeatletter
 \newcommand{\@assignment}[0]{Assignment}
 \newcommand{\assignment}[1]{\renewcommand{\@assignment}{#1}}
+\newcommand{\@supervisor}[0]{Your Supervisor's Name}
+\newcommand{\supervisor}[1]{\renewcommand{\@supervisor}{#1}}
+\newcommand{\@yearofstudy}[0]{3\textsuperscript{rd}}
+\newcommand{\yearofstudy}[1]{\renewcommand{\@yearofstudy}{#1}}
 \makeatletter
 
 \newtoggle{IsDissertation}

--- a/common/project.tex
+++ b/common/project.tex
@@ -4,7 +4,7 @@
 
 \author{Your name}
 \title{Project title}
-\supervisor{Your supervisor's name}
-\yearofstudy{3\textsuperscript{rd}}
+% \supervisor{Your supervisor's name}
+% \yearofstudy{3\textsuperscript{rd}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/common/project.tex
+++ b/common/project.tex
@@ -4,5 +4,7 @@
 
 \author{Your name}
 \title{Project title}
+\supervisor{Your supervisor's name}
+\yearofstudy{3\textsuperscript{rd}}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/common/titlepage.tex
+++ b/common/titlepage.tex
@@ -1,36 +1,39 @@
 \makeatletter
 \begin{titlepage}
 
-% do not show the assignment name for the dissertation
-\iftoggle{IsDissertation}
-{
-    \textbf{\Huge \@title} \\[1.5cm]
-}
-{
-    \textbf{\Huge \@title} \\
-    \Large \@assignment \\[1.5cm]
-}
-\Large \textbf{\@author} \\
-Department of Computer Science \\
-University of Warwick \\
+    % do not show the assignment name for the dissertation
+    \iftoggle{IsDissertation}
+    {
+        \textbf{\Huge \@title} \\[1.5cm]
+    }
+    {
+        \textbf{\Huge \@title} \\
+        \Large \@assignment \\[1.5cm]
+    }
+    \Large \textbf{\@author} \\
+    Department of Computer Science \\
+    University of Warwick \\
 
-% Include the 
-\iftoggle{IsDissertation}{
-    Supervised by \@supervisor \\
-    Year of Study: \@yearofstudy \\[1.5cm]
-}{}
+    % include the supervisor and year of study if the are specified and its the disseration
+    \iftoggle{IsDissertation}{
+        \ifdefempty{\@supervisor}{}{
+            Supervised by \@supervisor \\
+        }\ifdefempty{\@yearofstudy}{}{
+            Year of Study: \@yearofstudy \\
+        }
+    }{}
 
-\vfill
+    \vfill
 
-% include the current date for the dissertation
-\iftoggle{IsDissertation}{\today}{}
+    % include the current date for the dissertation
+    \iftoggle{IsDissertation}{\today}{}
 
-\begin{adjustwidth}{-\oddsidemargin-1in}{-\rightmargin}
-    \centering
-    \includegraphics[width=\paperwidth]{../common/line.png}
-\end{adjustwidth}
+    \begin{adjustwidth}{-\oddsidemargin-1in}{-\rightmargin}
+        \centering
+        \includegraphics[width=\paperwidth]{../common/line.png}
+    \end{adjustwidth}
 
-\vspace*{-3.5cm}
+    \vspace*{-3.5cm}
 
 \end{titlepage}
 \makeatother

--- a/common/titlepage.tex
+++ b/common/titlepage.tex
@@ -8,13 +8,19 @@
 }
 {
     \textbf{\Huge \@title} \\
-    \Large \@assignment \\[1.5cm] 
+    \Large \@assignment \\[1.5cm]
 }
 \Large \textbf{\@author} \\
 Department of Computer Science \\
 University of Warwick \\
 
-\vfill 
+% Include the 
+\iftoggle{IsDissertation}{
+    Supervised by \@supervisor \\
+    Year of Study: \@yearofstudy \\[1.5cm]
+}{}
+
+\vfill
 
 % include the current date for the dissertation
 \iftoggle{IsDissertation}{\today}{}


### PR DESCRIPTION
https://warwick.ac.uk/fac/sci/dcs/teaching/material/cs310/components/final/format/ specifies that the supervisor and year of study must be on the title page which the template currently does not support. This pull request defines the appropriate macros and text for the title page to include only on the dissertation.