### PR TITLE
Remove duplicate `\makeatletter`

### DIFF
--- a/common/common.tex
+++ b/common/common.tex
@@ -43,6 +43,5 @@
 \newcommand{\supervisor}[1]{\renewcommand{\@supervisor}{#1}}
 \newcommand{\@yearofstudy}[0]{}
 \newcommand{\yearofstudy}[1]{\renewcommand{\@yearofstudy}{#1}}
-\makeatletter
 
 \newtoggle{IsDissertation}


### PR DESCRIPTION
Removal of `\makeatletter` on line 46, query if intended to use `\makeatother` although note this will cause errors to later \@<command> uses in the script. 