### PR TITLE
Fix compilation (dvipsnames flag)

### DIFF
--- a/common/common.tex
+++ b/common/common.tex
@@ -17,7 +17,7 @@
 \usepackage{titletoc}
 \usepackage[explicit]{titlesec}
 \usepackage{natbib}
-\usepackage[dvipsnames]{xcolor}
+\usepackage{xcolor}
 \usepackage[sc]{mathpazo}
 \linespread{1.05}
 \usepackage[T1]{fontenc}

--- a/dissertation/dissertation.tex
+++ b/dissertation/dissertation.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,fleqn,twoside,12pt]{report}
+\documentclass[a4paper,fleqn,twoside,12pt,dvipsnames]{report}
 
 %%%%%%%%%%%%%%%%%%%%
 

--- a/progress-report/progress-report.tex
+++ b/progress-report/progress-report.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,fleqn,twoside,12pt]{article}
+\documentclass[a4paper,fleqn,twoside,12pt,dvipsnames]{article}
 
 %%%%%%%%%%%%%%%%%%%%
 

--- a/specification/specification.tex
+++ b/specification/specification.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,fleqn,12pt]{article}
+\documentclass[a4paper,fleqn,12pt,dvipsnames]{article}
 
 %%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
The `dvipsnames` flag being passed to `xcolor` was breaking compilation, since `xcolor` had already been imported with no flags by another library, causing a conflict. This broke the GH action for building.